### PR TITLE
fixed missing spec, fixed .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 coverage.txt
-loader.go
 profile.out
 .workspace

--- a/spec/loader.go
+++ b/spec/loader.go
@@ -1,0 +1,24 @@
+package spec
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Loader represents the business logic implementation usable in command line
+// tools.
+type Loader interface {
+	// Boot initializes and executes the command line tool.
+	Boot()
+
+	// ExecGenerateCmd executes the generate command.
+	ExecGenerateCmd(cmd *cobra.Command, args []string)
+
+	// ExecVersionCmd executes the version command.
+	ExecVersionCmd(cmd *cobra.Command, args []string)
+
+	// InitGenerateCmd initializes the generate command.
+	InitGenerateCmd() *cobra.Command
+
+	// InitVersionCmd initializes the version command.
+	InitVersionCmd() *cobra.Command
+}


### PR DESCRIPTION
During development I did not notice a little bug within the `.gitignore` file. The `spec` folder was missing. I noticed this after merging the initial PR when `go get` failed. This PR fixes the missing `spec` directory. 